### PR TITLE
Corrections to buggy_function

### DIFF
--- a/Agocs/template/buggy_function.py
+++ b/Agocs/template/buggy_function.py
@@ -20,8 +20,10 @@ def angle_to_sexigesimal(angle_in_degrees, decimals=3):
     if math.floor(decimals) != decimals:
         raise OSError('decimals should be an integer!')
 
-    hours_num = angle_in_degrees*24/180
+    hours_num = angle_in_degrees*24./360.
     hours = math.floor(hours_num)
+    hours_num -= 24*int(hours)//24
+    hours -= 24*int(hours)//24 
 
     min_num = (hours_num - hours)*60
     minutes = math.floor(min_num)


### PR DESCRIPTION
Fixes in buggy_function:

- corrected typo in RA formula,
- converted output RA hours to be mod 24, so no hours >24 are returned.

Remaining issues in buggy_function:

- due to limits in numerical accuracy, sometimes 60 second don't get converted to 1 minute.